### PR TITLE
- Exposed the size of the frame queue; it can now be set through PS3E…

### DIFF
--- a/src/ps3eye.h
+++ b/src/ps3eye.h
@@ -37,7 +37,7 @@ public:
 	PS3EYECam(libusb_context* context, libusb_device *device);
 	~PS3EYECam();
 
-	bool init(uint32_t width = 0, uint32_t height = 0, uint8_t desiredFrameRate = 30);
+	bool init(uint32_t width = 0, uint32_t height = 0, uint8_t desiredFrameRate = 30, uint32_t frame_buffer_count = 2);
 	void start();
 	void stop();
 
@@ -198,6 +198,7 @@ private:
 	uint32_t frame_height;
 	uint32_t frame_stride;
 	uint8_t frame_rate;
+	uint32_t frame_queue_size;
 
 	//usb stuff
 	libusb_context *device_context;


### PR DESCRIPTION
…YECam::init()
- Default size of the frame queue is now 2 (instead of 16) to increase responsiveness
- FrameQueue::Enqueue will no longer block if there is no room in the buffer (instead will overwrite the previous frame). This allows the service to degrade gracefully: if the consumer is not fast enough (< Camera FPS), it will miss frames, but if it is fast enough (>= Camera FPS), it will see everything.
